### PR TITLE
fixed erasing read-only eshell buffer

### DIFF
--- a/demo-it.el
+++ b/demo-it.el
@@ -284,8 +284,9 @@ STEPS is a list of functions to execute."
 
      (insert (concat "cd " directory))
      (eshell-send-input)
-     (erase-buffer)
-     (eshell-send-input)
+     (let ((inhibit-read-only t))
+       (erase-buffer)
+       (eshell-send-input))
 
      (when shell-line
        (insert shell-line)


### PR DESCRIPTION
Hey,
I am really enjoying watching your emacs vids and reading your literate emacs configuration, thanks!

While playing with demo-it, I was getting "let: Text is read-only" when trying to demo a command in eshell. It seems that the buffer is read-only, so erase-buffer failed. I wrapped it with inhibit-read-only and it seems to work well now.

Thanks!
