### PR TITLE
Fix footer format

### DIFF
--- a/demo-it.el
+++ b/demo-it.el
@@ -541,4 +541,4 @@ your own version of this, but it does the following:
 
 (provide 'demo-it)
 
-;;; demo-it ends here
+;;; demo-it.el ends here


### PR DESCRIPTION
Github diff view looks strange. This change is here.

``` patch
diff --git a/demo-it.el b/demo-it.el
index c345eb0..9550bc8 100644
--- a/demo-it.el
+++ b/demo-it.el
@@ -541,4 +541,4 @@ your own version of this, but it does the following:

 (provide 'demo-it)

-;;; demo-it ends here
+;;; demo-it.el ends here

```

I changed `demo-it` => `demo-it.el`.
