### PR TITLE
Correct package header format

### DIFF
--- a/demo-it.el
+++ b/demo-it.el
@@ -1,4 +1,4 @@
-;;; DEMO-IT --- Create demonstrations
+;;; demo-it.el --- Create demonstrations
 ;;
 ;; Author: Howard Abrams <howard.abrams@gmail.com>
 ;; Copyright (C) 2014  Howard Abrams


### PR DESCRIPTION
package.el cannot retrieve package description if package header is not correct.