### PR TITLE
Having a read-only shell prompt made demo-it shell commands error

### DIFF
--- a/demo-it.el
+++ b/demo-it.el
@@ -514,10 +514,12 @@ both buffers."
   "Uses comint-clear-buffer in Emacs >=25, otherwise erase buffer. Better
 compatibility with read-only shell-mode prompts"
   (let ((inhibit-read-only t))
-    (if (fboundp 'comint-clear-buffer)
-        (progn (comint-clear-buffer)
-               t)
-     (erase-buffer))))
+    (if (and (fboundp 'comint-clear-buffer)
+             (derived-mode-p 'comint-mode))
+        (progn
+          (comint-clear-buffer)
+          t)
+      (erase-buffer))))
 
 (defun demo-it-start-shell (&optional directory command name
                                       side size width)

--- a/demo-it.el
+++ b/demo-it.el
@@ -510,6 +510,15 @@ both buffers."
 ;;    Kick off a shell in another window, change to a particular
 ;;    directory, and automatically run something.
 
+(defun demo-it--erase-shell-buffer ()
+  "Uses comint-clear-buffer in Emacs >=25, otherwise erase buffer. Better
+compatibility with read-only shell-mode prompts"
+  (let ((inhibit-read-only t))
+    (if (fboundp 'comint-clear-buffer)
+        (progn (comint-clear-buffer)
+               t)
+     (erase-buffer))))
+
 (defun demo-it-start-shell (&optional directory command name
                                       side size width)
   "Start a shell or eshell instance, and change to DIRECTORY to
@@ -553,8 +562,8 @@ in a particular DIRECTORY."
 
     (text-scale-set (demo-it--get-text-scale size))
 
-    (erase-buffer)
-    (demo-it-insert-shell "" :instant)))
+    (unless (demo-it--erase-shell-buffer)
+      (demo-it-insert-shell "" :instant))))
 
 (defun demo-it--start-shell-reuse (title directory)
   "Attempt to re-use existing shell/eshell with a buffer named
@@ -563,8 +572,8 @@ TITLE in a particular DIRECTORY."
   (when directory
     (goto-char (point-max))
     (demo-it-insert-shell (format "cd %s" directory) :instant)
-    (erase-buffer)
-    (demo-it-insert-shell "" :instant)))
+    (unless (demo-it--erase-shell-buffer)
+      (demo-it-insert-shell "" :instant))))
 
 (defun demo-it--shell-buffer-name (&optional name)
   "Return the buffer NAME for the shell or eshell window."


### PR DESCRIPTION
This uses the code from comint-clear-buffer if it exists, and otherwise falls
back to existing functionality of (erase-buffer), but with inhibit-read-only
set.